### PR TITLE
feat: integrate openrouter api via secret

### DIFF
--- a/.github/workflows/openrouter.yml
+++ b/.github/workflows/openrouter.yml
@@ -1,0 +1,24 @@
+name: openrouter-eval
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-evaluator:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run iterative evaluation with OpenRouter
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.CONSTRUCTORTEST }}
+          OPENROUTER_BASE_URL: https://openrouter.ai/api/v1
+          OPENROUTER_MODEL: openai/gpt-4o-mini
+          LLM_PROVIDER: openrouter
+        run: make run-iteratively USE_LLM=true

--- a/generate_fixes.py
+++ b/generate_fixes.py
@@ -13,13 +13,23 @@ except Exception:  # pragma: no cover - optional dependency
 def call_openrouter_api(prompt):
     """
     Calls the OpenRouter API with the given prompt.
-    """
-    api_key = os.environ.get("OPENROUTER_API_KEY")
-    base_url = os.environ.get("OPENROUTER_BASE_URL")
-    model = os.environ.get("OPENROUTER_MODEL")
 
-    if not all([api_key, base_url, model]):
-        raise ValueError("Please set the OPENROUTER_API_KEY, OPENROUTER_BASE_URL, and OPENROUTER_MODEL environment variables.")
+    Looks for standard OpenRouter environment variables and falls back to
+    the GitHub secret `CONSTRUCTORTEST` for the API key. Defaults are
+    provided for the base URL and model so that only the key needs to be
+    configured in most setups.
+    """
+    api_key = (
+        os.environ.get("OPENROUTER_API_KEY")
+        or os.environ.get("CONSTRUCTORTEST")
+    )
+    base_url = os.environ.get("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
+    model = os.environ.get("OPENROUTER_MODEL", "openai/gpt-4o-mini")
+
+    if not api_key:
+        raise ValueError(
+            "Please set OPENROUTER_API_KEY or CONSTRUCTORTEST with your OpenRouter API key."
+        )
 
     headers = {
         "Authorization": f"Bearer {api_key}",


### PR DESCRIPTION
## Summary
- allow `generate_fixes.py` to read OpenRouter creds from `CONSTRUCTORTEST` secret with sensible defaults
- add GitHub Action to run iterative evaluation using OpenRouter

## Testing
- `make run-autocheck`

------
https://chatgpt.com/codex/tasks/task_e_68c4aea47774832db4a6cd9d84b76190