### PR TITLE
feat: integrate openrouter api via secret

### DIFF
--- a/.github/workflows/openrouter.yml
+++ b/.github/workflows/openrouter.yml
@@ -1,0 +1,24 @@
+name: openrouter-eval
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-evaluator:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run iterative evaluation with OpenRouter
+        env:
+          CONSTRUCTORTEST: ${{ secrets.CONSTRUCTORTEST }}
+          OPENROUTER_BASE_URL: https://openrouter.ai/api/v1
+          OPENROUTER_MODEL: openai/gpt-4o-mini
+          LLM_PROVIDER: openrouter
+        run: make run-iteratively USE_LLM=true

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ clean:
 
 run-iteratively:
 	@if [ "$(USE_LLM)" = "true" ]; then \
-		echo "Using LLM to generate fixes. Make sure OPENROUTER_API_KEY, OPENROUTER_BASE_URL, and OPENROUTER_MODEL are set."; \
+		echo "Using LLM to generate fixes. Make sure CONSTRUCTORTEST, OPENROUTER_BASE_URL, and OPENROUTER_MODEL are set."; \
 		for i in $$(seq 1 5); do \
 			echo "---- Running Iteration $$i ----"; \
 			make prompts OUT_DIR=out_run_$$i; \

--- a/generate_fixes.py
+++ b/generate_fixes.py
@@ -13,13 +13,19 @@ except Exception:  # pragma: no cover - optional dependency
 def call_openrouter_api(prompt):
     """
     Calls the OpenRouter API with the given prompt.
-    """
-    api_key = os.environ.get("OPENROUTER_API_KEY")
-    base_url = os.environ.get("OPENROUTER_BASE_URL")
-    model = os.environ.get("OPENROUTER_MODEL")
 
-    if not all([api_key, base_url, model]):
-        raise ValueError("Please set the OPENROUTER_API_KEY, OPENROUTER_BASE_URL, and OPENROUTER_MODEL environment variables.")
+    Uses the `CONSTRUCTORTEST` environment variable for the API key.
+    Defaults are provided for the base URL and model so that only the key
+    needs to be configured in most setups.
+    """
+    api_key = os.environ.get("CONSTRUCTORTEST")
+    base_url = os.environ.get("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
+    model = os.environ.get("OPENROUTER_MODEL", "openai/gpt-4o-mini")
+
+    if not api_key:
+        raise ValueError(
+            "Please set CONSTRUCTORTEST with your OpenRouter API key."
+        )
 
     headers = {
         "Authorization": f"Bearer {api_key}",


### PR DESCRIPTION
## Summary
- simplify OpenRouter key lookup to only use `CONSTRUCTORTEST`
- adjust Makefile and workflow to reference `CONSTRUCTORTEST` env var

## Testing
- `make run-autocheck`
- `CONSTRUCTORTEST=dummytoken python3 generate_fixes.py --prompts-dir out/prompts --fixes-dir out/llm_fixes --use-llm` *(fails: ProxyError 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c4aea47774832db4a6cd9d84b76190