### PR TITLE
Remove negative margin from image markdown containers

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1058,6 +1058,16 @@ def score_item(item: Dict[str, Any], interest: str, lo: Optional[float], hi: Opt
 
 # ----------------------- UI -----------------------
 st.set_page_config(page_title="Gift Finder", page_icon="🎁", layout="centered")
+st.markdown(
+    """
+    <style>
+    div[data-testid="stMarkdownContainer"]:has(> div[data-image-box]) {
+        margin: 0 !important;
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
 st.title("Gift Finder")
 st.caption("Choose match mode and amounts, then select recipient details.")
 
@@ -1390,7 +1400,7 @@ with tabs[0]:
             safe_alt = html.escape(alt_text or "")
             st.markdown(
                 f"""
-                <div style="width: 100%; height: {height}px; overflow: hidden; border-radius: 12px; border: 1px solid #ddd;">
+                <div data-image-box style="width: 100%; height: {height}px; overflow: hidden; border-radius: 12px; border: 1px solid #ddd;">
                     <img src="{src}" alt="{safe_alt}" style="width: 100%; height: 100%; object-fit: cover; display: block;" />
                 </div>
                 """,


### PR DESCRIPTION
## Summary
- inject a global style override that removes the negative margin applied to markdown containers that host the image cards
- tag rendered image wrappers so the style targets only those containers without disturbing other markdown content

## Testing
- python -m compileall streamlit_app.py

------
https://chatgpt.com/codex/tasks/task_e_68ca31adb12c832daab3a3152e959f9c