### PR TITLE
Add metadata-driven query interpreter and simplify image hints

### DIFF
--- a/src/query_interpreter.py
+++ b/src/query_interpreter.py
@@ -1,125 +1,115 @@
-"""Hybrid enrichment layer that expands filtered tokens into gift-friendly terms."""
+"""
+query_interpreter.py
+Hybrid interpreter with:
+  - metadata-driven inference of style, palette, cohort
+  - multi-query composer (Fashion, Books, Tech, Outdoors, Home)
+  - optional LLM rewrite with strict allow-list
+  - confidence scoring; suggest probing images if signal is weak
+
+Assumptions:
+  unsplash_images/metadata.json contains, per photo:
+    {
+      "id": "ph_001",
+      "tags": ["art","retro","vinyl"],
+      "style": ["minimalist","90s","casual"],   # optional
+      "palette": ["black","blue","neutral"],    # optional
+      "cohort": "Gen X"                          # optional
+    }
+
+Usage (typical):
+  qi = QueryInterpreter()
+  res = qi.interpret(
+      tokens=filtered_tokens,            # from QueryBuilder
+      categories=categories,             # from QueryBuilder
+      photo_ids=selected_photo_ids,      # from UI
+      budget_aud=(25,100),
+      use_llm=True
+  )
+  if res["need_more_images"]:
+      # Ask UI to show res["probe_tags"] / res["probe_axes"] focused images
+  else:
+      # Send res["queries_multi"] (bucket, query) to Constructor
+"""
 
 from __future__ import annotations
-
-import json
-import os
-import re
+import json, os, math
+from collections import Counter
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, TypedDict, Literal
+from typing import Any, Dict, List, Optional, Tuple, Literal
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
 
 DEFAULT_METADATA_PATH = "unsplash_images/metadata.json"
 DEFAULT_MANIFEST_PATH = "queries_manifest.json"
 
+Bucket = Literal["Fashion","Books","Tech","Outdoors","Home","Entertainment"]
+
 FORBIDDEN = {
-    "girl",
-    "girls",
-    "boy",
-    "boys",
-    "woman",
-    "women",
-    "man",
-    "men",
-    "female",
-    "male",
-    "lady",
-    "gentleman",
-    "ladies",
-    "gent",
-    "gents",
-    "adult",
-    "adults",
-    "teen",
-    "teens",
-    "kid",
-    "kids",
-    "child",
-    "children",
-    "mum",
-    "mom",
-    "dad",
-    "grandma",
-    "grandpa",
+    "girl","girls","boy","boys","woman","women","man","men","female","male",
+    "adult","adults","kids","children","mum","mom","dad","grandma","grandpa",
+    "lady","gentleman"
 }
 
+# Lightweight vibe → cohort hints (fallback if metadata lacks cohort)
 TOKEN_TO_COHORT = {
     "vintage": "Gen X / Millennial nostalgia",
     "retro": "Millennial nostalgia",
-    "90s": "Millennial nostalgia",
-    "aesthetic": "Gen Z vibe",
+    "90s": "Gen X / Millennial",
+    "aesthetic": "Gen Z",
     "festival": "Gen Z / Millennial",
     "classic": "Gen X / Boomer",
-    "film": "Gen X / Millennial",
     "polaroid": "Gen X / Millennial",
-    "tiktok": "Gen Z vibe",
-    "neon": "Gen Z vibe",
-    "y2k": "Gen Z vibe",
-    "streetwear": "Gen Z vibe",
-    "cottagecore": "Millennial / Gen Z",
+    "neon": "Gen Z",
 }
 
+# Token → product seed terms (deterministic)
 TOKEN_TO_PRODUCT_TERMS: Dict[str, List[str]] = {
-    "summer": ["sunglasses", "sun hat", "beach towel", "cooler bag"],
-    "sun": ["sunglasses", "sunscreen set", "cap"],
-    "beach": ["beach towel", "dry bag", "sand-proof blanket"],
-    "outdoor": ["insulated bottle", "daypack", "picnic set", "camping mug"],
-    "outdoors": ["insulated bottle", "daypack", "picnic set", "camping mug"],
-    "hiking": ["trekking socks", "trail snacks", "hydration flask", "compact first-aid kit"],
-    "camping": ["enamel mug", "compact lantern", "firestarter kit"],
-    "window": ["indoor plant kit", "aromatherapy diffuser", "scented candle", "ceramic vase"],
-    "home": ["throw blanket", "candle", "planter", "coaster set"],
-    "retro": ["vinyl record", "retro poster", "polaroid film"],
-    "vintage": ["vinyl record", "analogue photo album"],
-    "vinyl": ["record", "anti-static brush", "slipmat"],
-    "coffee": ["pour-over kit", "hand grinder", "ceramic mug", "cold brew bottle"],
-    "tea": ["loose leaf sampler", "teapot infuser"],
-    "gaming": ["controller stand", "desk mat", "headset holder"],
-    "book": ["gift book", "journal", "reading light"],
-    "books": ["gift book", "journal", "reading light"],
-    "craft": ["ceramic kit", "embroidery kit", "leather key kit"],
-    "crafts": ["ceramic kit", "embroidery kit", "leather key kit"],
-    "travel": ["packing cubes", "weekender bag", "passport wallet"],
-    "minimalist": ["clean desk organiser", "wireless charger", "matte water bottle"],
-    "minimal": ["clean desk organiser", "wireless charger", "matte water bottle"],
-    "art": ["art print", "museum membership", "colouring book for adults"],
-    "forest": ["hiking socks", "outdoor blanket"],
-    "mountain": ["daypack", "insulated bottle"],
-    "mountains": ["daypack", "insulated bottle"],
+    "summer": ["sunglasses","sun hat","beach towel","cooler bag"],
+    "sun": ["sunscreen set","cap","sunglasses"],
+    "beach": ["beach towel","dry bag","sand-proof blanket"],
+    "outdoor": ["insulated bottle","daypack","picnic set","camping mug"],
+    "hiking": ["trekking socks","hydration flask","compact first-aid kit"],
+    "camping": ["enamel mug","compact lantern","firestarter kit"],
+    "window": ["indoor plant kit","aromatherapy diffuser","scented candle","ceramic vase"],
+    "home": ["throw blanket","planter","coaster set"],
+    "retro": ["vinyl record","retro poster","polaroid film"],
+    "vintage": ["vinyl record","analogue photo album"],
+    "vinyl": ["record","anti-static brush","slipmat"],
+    "coffee": ["pour-over kit","hand grinder","ceramic mug","cold brew bottle"],
+    "tea": ["loose leaf sampler","teapot infuser"],
+    "gaming": ["controller stand","desk mat","headset holder"],
+    "books": ["gift book","journal","reading light"],
+    "book": ["gift book","journal","reading light"],
+    "crafts": ["ceramic kit","embroidery kit"],
+    "travel": ["packing cubes","weekender bag","passport wallet"],
+    "minimalist": ["clean desk organiser","wireless charger","matte water bottle"],
+    "art": ["art print","museum membership","colouring book for adults"],
+    "philosophy": ["gift book","journal"],
+    "tech": ["power bank","wireless charger","bluetooth tracker"],
+    "nature": ["insulated bottle","hiking socks"],
 }
 
 CATEGORY_TO_DEFAULT_TERMS: Dict[str, List[str]] = {
-    "Outdoors": ["sunglasses", "insulated bottle", "daypack", "picnic set", "camping mug"],
-    "Home": ["aromatherapy diffuser", "scented candle", "indoor plant kit", "ceramic vase"],
-    "Tech": ["power bank", "wireless charger", "bluetooth tracker"],
-    "Entertainment": ["board game", "vinyl record", "bluetooth speaker"],
-    "Books": ["gift book", "journal", "reading light"],
-    "Fashion": ["cap", "scarf", "sunglasses"],
-    "Food": ["gourmet chocolate", "coffee beans", "tea sampler"],
-    "Crafts": ["ceramic kit", "embroidery kit", "woodcraft kit"],
-    "Sports": ["yoga mat", "microfibre towel", "sports bottle"],
-    "Travel": ["packing cubes", "weekender bag", "passport wallet"],
+    "Outdoors": ["sunglasses","insulated bottle","daypack","picnic set","camping mug"],
+    "Home": ["aromatherapy diffuser","scented candle","indoor plant kit","ceramic vase"],
+    "Tech": ["power bank","wireless charger","bluetooth tracker"],
+    "Entertainment": ["board game","vinyl record","bluetooth speaker"],
+    "Books": ["gift book","journal","reading light"],
+    "Fashion": ["cap","sunglasses","scarf"],
+    "Food": ["gourmet chocolate","coffee beans","tea sampler"],
+    "Crafts": ["ceramic kit","embroidery kit","woodcraft kit"],
+    "Sports": ["yoga mat","microfibre towel","sports bottle"],
+    "Travel": ["packing cubes","weekender bag","passport wallet"],
 }
-
-
-# --- New: multi-query composer with user hints -------------------------------
-
-Bucket = Literal["Fashion", "Books", "Tech", "Outdoors", "Home", "Entertainment"]
-
-
-class Hints(TypedDict, total=False):
-    recipient: str  # "me","man","woman","teen","kid","couple","family"
-    colours: List[str]
-    styles: List[str]  # ["casual","minimalist","retro","90s","practical","premium"]
-    budget_aud: Tuple[int | None, int | None]
-    cohort: str  # e.g., "Gen X"
-
 
 BUCKET_TEMPLATES: Dict[Bucket, str] = {
     "Fashion": "{styles} {palette} clothes {recipient_phrase} {cohort_twist} under {hi}",
-    "Books": "books and ideas on {themes} {recipient_phrase} under {hi}",
-    "Tech": "tech and gadgets {style_practical} {recipient_phrase} under {hi}",
-    "Outdoors": "{palette} outdoor gear and apparel {recipient_phrase} under {hi}",
-    "Home": "{palette} home items {style_practical} {recipient_phrase} under {hi}",
+    "Books": "books and ideas on {themes} {recipient_phrase} {cohort_twist} under {hi}",
+    "Tech": "tech and gadgets {style_practical} {recipient_phrase} {cohort_twist} under {hi}",
+    "Outdoors": "{palette} outdoor gear and apparel {recipient_phrase} {cohort_twist} under {hi}",
+    "Home": "{palette} home items {style_practical} {recipient_phrase} {cohort_twist} under {hi}",
 }
 
 STYLE_PHRASES = {
@@ -138,19 +128,42 @@ COHORT_PHRASE = {
     "Boomer": "classic",
 }
 
-PALETTE_CANON = {
-    "black": "black",
-    "blue": "blue",
-    "neutral": "neutral",
-    "natural": "earthy",
-    "earthy": "earthy",
-    "warm": "warm",
-    "neon": "neon",
-}
+# ---------------------------------------------------------------------------
+# Utils
+# ---------------------------------------------------------------------------
 
+def _read_json(path: Path) -> Any:
+    if not path.exists():
+        return None
+    try: return json.loads(path.read_text())
+    except Exception: return None
 
-def _recipient_phrase(h: Hints) -> str:
-    rec = (h.get("recipient") or "me").lower()
+def _normalise(xs: List[str]) -> List[str]:
+    out = []
+    for t in xs or []:
+        t = (t or "").strip().lower()
+        if not t or t in FORBIDDEN: continue
+        t = t.replace("_","-")
+        if t == "cosy": t = "cozy"
+        out.append(t)
+    # dedupe preserve order
+    seen, keep = set(), []
+    for t in out:
+        if t not in seen:
+            seen.add(t); keep.append(t)
+    return keep
+
+def _entropy_from_counts(counter: Counter) -> float:
+    total = sum(counter.values()) or 1
+    ent = 0.0
+    for _, n in counter.items():
+        p = n / total
+        if p > 0:
+            ent -= p * math.log2(p)
+    return ent
+
+def _recipient_phrase(recipient: Optional[str]) -> str:
+    rec = (recipient or "me").lower()
     return {
         "me": "for me",
         "man": "for men",
@@ -161,418 +174,281 @@ def _recipient_phrase(h: Hints) -> str:
         "family": "for families",
     }.get(rec, "for me")
 
+def _palette_phrase(colours: List[str] | None) -> str:
+    if not colours: return ""
+    keep = [c for c in colours if c in {"black","blue","neutral","earthy"}]
+    return ("in " + " and ".join(keep)) if keep else ""
 
-def _palette_phrase(colours: Optional[List[str]]) -> str:
-    if not colours:
-        return ""
-    mapped = []
-    for colour in colours:
-        if not colour:
-            continue
-        canon = PALETTE_CANON.get(colour.lower())
-        if canon:
-            mapped.append(canon)
-    seen: set[str] = set()
-    keep = [c for c in mapped if not (c in seen or seen.add(c))]
-    if not keep:
-        return ""
-    return "in " + " and ".join(keep)
-
-
-def _styles_phrase(styles: Optional[List[str]]) -> Tuple[str, str]:
-    if not styles:
-        return "", ""
+def _styles_phrase(styles: List[str] | None) -> Tuple[str, str]:
+    if not styles: return "", ""
     mapped = [STYLE_PHRASES.get(s.lower(), s.lower()) for s in styles]
     style_str = " ".join(sorted(set(mapped)))
-    practical = ""
-    if "practical" in mapped:
-        practical = "that are practical"
-    elif "plain" in mapped:
-        practical = "that are plain and practical"
+    practical = "that are practical" if "practical" in mapped else "that are plain and practical" if "plain" in mapped else ""
     return style_str, practical
 
-
 def _themes_from_tokens(tokens: List[str]) -> str:
-    keep = [t for t in tokens if t in {"philosophy", "art", "tech", "nature", "design"}]
-    return " and ".join(keep) if keep else "philosophy and tech"
+    keep = [t for t in tokens if t in {"philosophy","art","tech","nature","design","book"}]
+    return " and ".join(sorted(set(keep))) if keep else "philosophy and tech"
 
+# ---------------------------------------------------------------------------
+# LLM rewrite (optional, allowed-terms only)
+# ---------------------------------------------------------------------------
 
-def compose_queries_multi(
-    tokens: List[str],
-    categories: List[str],
-    hints: Hints,
-    cohort_hint: Optional[str] = None,
-) -> List[Tuple[Bucket, str]]:
-    _lo, hi = hints.get("budget_aud") or (None, None)
-    recipient = _recipient_phrase(hints)
-    palette = _palette_phrase(hints.get("colours"))
-    styles, style_practical = _styles_phrase(hints.get("styles"))
-    cohort = cohort_hint or hints.get("cohort")
-    cohort_twist = COHORT_PHRASE.get(cohort or "", "").strip()
-
-    buckets: List[Bucket] = []
-    if "Fashion" in categories or any(t in tokens for t in ("casual", "retro", "90s", "minimalist")):
-        buckets.append("Fashion")
-    if "Books" in categories or any(t in tokens for t in ("book", "philosophy", "art", "tech", "design")):
-        buckets.append("Books")
-    if "Tech" in categories or "tech" in tokens:
-        buckets.append("Tech")
-    if "Outdoors" in categories or any(
-        t in tokens for t in ("outdoor", "nature", "hiking", "camping", "summer", "sun", "beach")
-    ):
-        buckets.append("Outdoors")
-    if "Home" in categories or "window" in tokens:
-        buckets.append("Home")
-    seen: set[str] = set()
-    buckets = [b for b in buckets if not (b in seen or seen.add(b))][:5]
-    if not buckets:
-        buckets = ["Tech", "Books"]
-
-    themes = _themes_from_tokens(tokens)
-    if isinstance(hi, (int, float)) and hi:
-        budget_phrase = f"${int(hi)}"
-    else:
-        budget_phrase = "$100"
-
-    out: List[Tuple[Bucket, str]] = []
-    for bucket in buckets:
-        template = BUCKET_TEMPLATES[bucket]
-        query = template.format(
-            styles=styles or "casual",
-            palette=palette,
-            recipient_phrase=recipient,
-            cohort_twist=f"{cohort_twist}" if cohort_twist else "",
-            style_practical=style_practical or "that are plain and practical",
-            themes=themes,
-            hi=budget_phrase,
-        )
-        query = " ".join(query.split())
-        out.append((bucket, query))
-    return out
-
-
-def _read_json(path: Path) -> Any:
-    if not path.exists():
-        return None
-    try:
-        return json.loads(path.read_text())
-    except Exception:
-        return None
-
-
-def _normalise_tokens(tokens: List[str] | None) -> List[str]:
-    cleaned: List[str] = []
-    for token in tokens or []:
-        norm = (token or "").strip().lower()
-        if not norm or norm in FORBIDDEN:
-            continue
-        norm = norm.replace("_", "-")
-        if norm == "cosy":
-            norm = "cozy"
-        cleaned.append(norm)
-    deduped: List[str] = []
-    seen: set[str] = set()
-    for token in cleaned:
-        if token not in seen:
-            seen.add(token)
-            deduped.append(token)
-    return deduped
-
-
-def _map_marker(label: str) -> Optional[str]:
-    text = (label or "").lower()
-    if "gen z" in text or "genz" in text:
-        return "Gen Z"
-    if "millennial" in text or "gen y" in text:
-        return "Millennial"
-    if "gen x" in text:
-        return "Gen X"
-    if "boomer" in text:
-        return "Boomer"
-    return None
-
-
-def _infer_from_node(node: Dict[str, Any], counts: Dict[str, int]) -> None:
-    for key in ("gen_marker", "cohort", "generation"):
-        value = node.get(key)
-        if isinstance(value, str):
-            value = [value]
-        if isinstance(value, list):
-            for item in value:
-                cohort = _map_marker(str(item))
-                if cohort:
-                    counts[cohort] = counts.get(cohort, 0) + 1
-    facets = node.get("facets")
-    if isinstance(facets, dict):
-        facet_vals = facets.get("gen_marker")
-        if isinstance(facet_vals, str):
-            facet_vals = [facet_vals]
-        if isinstance(facet_vals, list):
-            for item in facet_vals:
-                cohort = _map_marker(str(item))
-                if cohort:
-                    counts[cohort] = counts.get(cohort, 0) + 1
-
-
-def _infer_cohort_from_metadata(photo_ids: List[str], metadata: Any) -> Optional[str]:
-    if not metadata:
-        return None
-    counts: Dict[str, int] = {}
-
-    def record(candidate_ids: List[str], node: Dict[str, Any]) -> None:
-        if not isinstance(node, dict):
-            return
-        _infer_from_node(node, counts)
-
-    if isinstance(metadata, dict):
-        if "photos" in metadata:
-            return _infer_cohort_from_metadata(photo_ids, metadata.get("photos"))
-        for pid in photo_ids:
-            key = str(pid)
-            node = metadata.get(key)
-            if not isinstance(node, dict):
-                continue
-            record([key], node)
-    elif isinstance(metadata, list):
-        for node in metadata:
-            if not isinstance(node, dict):
-                continue
-            node_ids = []
-            if "id" in node:
-                node_ids.append(str(node["id"]))
-            if "photo_id" in node:
-                node_ids.append(str(node["photo_id"]))
-            if not node_ids:
-                continue
-            for pid in photo_ids:
-                if str(pid) in node_ids:
-                    record(node_ids, node)
-                    break
-    if not counts:
-        return None
-    items = sorted(counts.items(), key=lambda pair: pair[1], reverse=True)
-    best_label, best_count = items[0]
-    if len(items) == 1:
-        return best_label
-    second_count = items[1][1]
-    if best_count >= max(2, 2 * second_count):
-        return best_label
-    return best_label
-
-
-def _infer_cohort(tokens: List[str], photo_ids: List[str], metadata_path: Path) -> Optional[str]:
-    metadata = _read_json(metadata_path)
-    cohort = _infer_cohort_from_metadata(photo_ids, metadata)
-    if cohort:
-        return cohort
-    for token in tokens:
-        if token in TOKEN_TO_COHORT:
-            return TOKEN_TO_COHORT[token]
-    return None
-
-
-def _load_manifest(manifest_path: Path) -> Dict[str, Any]:
-    manifest = _read_json(manifest_path) or {}
-    tag_map = manifest.get("tag_to_categories", {})
-    manifest["tag_to_categories"] = {
-        (key or "").lower(): value for key, value in tag_map.items()
-    }
-    manifest["allowed_tokens"] = [
-        (token or "").lower() for token in manifest.get("allowed_tokens", [])
-    ]
-    manifest["forbidden_tokens"] = [
-        (token or "").lower() for token in manifest.get("forbidden_tokens", [])
-    ]
-    return manifest
-
-
-def _expand_categories(tokens: List[str], base_categories: List[str], manifest: Dict[str, Any]) -> List[str]:
-    categories = set(base_categories or [])
-    mapping = manifest.get("tag_to_categories", {})
-    for token in tokens:
-        for category in mapping.get(token, []) or []:
-            categories.add(category)
-    return sorted(categories)
-
-
-def _product_seeds(tokens: List[str], categories: List[str], max_terms: int) -> List[str]:
-    seeds: List[str] = []
-    for token in tokens:
-        seeds.extend(TOKEN_TO_PRODUCT_TERMS.get(token, []))
-    for category in categories:
-        seeds.extend(CATEGORY_TO_DEFAULT_TERMS.get(category, []))
-    normalised = _normalise_tokens(seeds)
-    output: List[str] = []
-    for term in normalised:
-        if term not in output and len(output) < max_terms:
-            output.append(term)
-    return output
-
-
-def _llm_rewrite(
-    allowed_terms: List[str],
-    cohort: Optional[str],
-    budget: Optional[Tuple[int, int]],
-) -> Optional[str]:
+def _llm_rewrite(allowed_terms: List[str], cohort: Optional[str], budget: Optional[Tuple[int,int]]) -> Optional[str]:
     api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        return None
+    if not api_key: return None
     try:
         from openai import OpenAI
-
         client = OpenAI(api_key=api_key)
-        use_v1 = True
-    except Exception:
-        try:
-            import openai
-
-            openai.api_key = api_key
-            use_v1 = False
-        except Exception:
-            return None
-
-    forbidden = ", ".join(sorted(FORBIDDEN))
-    prompt = (
-        "You will compose a concise gift search string.\n"
-        "You MAY ONLY use the provided ALLOWED_TERMS (reorder or omit as needed).\n"
-        "Do NOT add new nouns, age, gender, or relationship words.\n"
-        "Forbidden words: "
-        + forbidden
-        + "\n"
-        + "Output ONE line with no quotes, no punctuation lists.\n"
-        + f"ALLOWED_TERMS: {', '.join(allowed_terms)}\n"
-    )
-    if cohort:
-        prompt += f"Cohort vibe: {cohort}. Use it as flavour only, not demographics.\n"
-    if budget:
-        _low, high = budget
-        prompt += f"If natural, append 'under {high} AUD'.\n"
-
-    try:
-        if use_v1:
-            response = client.chat.completions.create(
-                model="gpt-4o-mini",
-                messages=[
-                    {"role": "system", "content": "Be precise, safe, and minimal."},
-                    {"role": "user", "content": prompt},
-                ],
-                temperature=0,
-            )
-            text = (response.choices[0].message.content or "").strip()
-        else:
-            response = openai.ChatCompletion.create(
-                model="gpt-4o-mini",
-                messages=[
-                    {"role": "system", "content": "Be precise, safe, and minimal."},
-                    {"role": "user", "content": prompt},
-                ],
-                temperature=0,
-            )
-            text = (response["choices"][0]["message"]["content"] or "").strip()
+        resp = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {"role":"system","content":"Compose a single clean gift search string."},
+                {"role":"user","content":(
+                    "Use ONLY these terms (reorder/trim ok). "
+                    "Do NOT add age/gender/demographics.\n"
+                    f"TERMS: {', '.join(allowed_terms)}\n"
+                    f"Cohort: {cohort or ''}\n"
+                    f"Budget: {'under '+str(budget[1])+' AUD' if budget else ''}\n"
+                    "Output: one line, no lists."
+                )}
+            ],
+            temperature=0
+        )
+        s = (resp.choices[0].message.content or "").strip().lower()
     except Exception:
         return None
-
-    output = re.sub(r"\s+", " ", text).strip().lower()
+    # Final sanitise
     for bad in FORBIDDEN:
-        output = output.replace(bad, "")
-    output = " ".join(output.split())
-    return output or None
+        s = s.replace(bad, "")
+    s = " ".join(s.split())
+    return s or None
 
+# ---------------------------------------------------------------------------
+# Interpreter class
+# ---------------------------------------------------------------------------
 
 class QueryInterpreter:
-    def __init__(
-        self,
-        manifest_path: str = DEFAULT_MANIFEST_PATH,
-        metadata_path: str = DEFAULT_METADATA_PATH,
-    ) -> None:
+    def __init__(self,
+                 manifest_path: str = DEFAULT_MANIFEST_PATH,
+                 metadata_path: str = DEFAULT_METADATA_PATH):
         self.manifest_path = Path(manifest_path)
         self.metadata_path = Path(metadata_path)
-        self.manifest = _load_manifest(self.manifest_path)
+        self.manifest = _read_json(self.manifest_path) or {}
+        # normalise tag_to_categories keys to lowercase
+        t2c = self.manifest.get("tag_to_categories", {})
+        self.tag_to_categories = { (k or "").lower(): v for k, v in t2c.items() }
+        # build quick id->meta index
+        meta = _read_json(self.metadata_path)
+        self.meta_index: Dict[str, Dict[str, Any]] = {}
+        if isinstance(meta, dict) and "photos" in meta:
+            meta = meta["photos"]
+        if isinstance(meta, list):
+            for m in meta:
+                if isinstance(m, dict) and "id" in m:
+                    self.meta_index[str(m["id"])] = m
+
+    # ---- inference from metadata -------------------------------------------
+
+    def _infer_style_palette_cohort(self, photo_ids: List[str]) -> Tuple[List[str], List[str], Optional[str], Dict[str, Counter]]:
+        style_ctr, palette_ctr, cohort_ctr = Counter(), Counter(), Counter()
+        for pid in photo_ids or []:
+            node = self.meta_index.get(str(pid)) or {}
+            for s in node.get("style", []) or []:
+                style_ctr[s.lower()] += 1
+            for c in node.get("palette", []) or []:
+                palette_ctr[c.lower()] += 1
+            coh = node.get("cohort")
+            if isinstance(coh, str):
+                cohort_ctr[coh] += 1
+
+        styles = [k for k, _ in style_ctr.most_common(3)]
+        palettes = [k for k, _ in palette_ctr.most_common(3)]
+        cohort = cohort_ctr.most_common(1)[0][0] if cohort_ctr else None
+        return styles, palettes, cohort, {"style": style_ctr, "palette": palette_ctr, "cohort": cohort_ctr}
+
+    # ---- category expansion -------------------------------------------------
+
+    def _expand_categories(self, tokens: List[str], base_categories: List[str]) -> List[str]:
+        cats = set(base_categories or [])
+        for t in tokens:
+            for c in self.tag_to_categories.get(t, []) or []:
+                cats.add(c)
+        return sorted(cats)
+
+    # ---- product seed expansion --------------------------------------------
+
+    def _product_seeds(self, tokens: List[str], categories: List[str], max_terms: int) -> List[str]:
+        seeds: List[str] = []
+        for t in tokens:
+            seeds += TOKEN_TO_PRODUCT_TERMS.get(t, [])
+        for c in categories:
+            seeds += CATEGORY_TO_DEFAULT_TERMS.get(c, [])
+        # normalise & dedupe
+        seeds = _normalise(seeds)
+        out: List[str] = []
+        for s in seeds:
+            if s not in out and len(out) < max_terms:
+                out.append(s)
+        return out
+
+    # ---- confidence & probing ----------------------------------------------
+
+    def _confidence(self, ctrs: Dict[str, Counter]) -> Dict[str, float]:
+        """Lower entropy = higher confidence."""
+        conf = {}
+        for axis, c in ctrs.items():
+            if not c:
+                conf[axis] = 0.0
+                continue
+            ent = _entropy_from_counts(c)
+            # normalise to [0..1] by dividing by log2(K) where K is number of bins
+            k = max(1, len(c))
+            max_ent = math.log2(k) if k > 1 else 1.0
+            score = 1.0 - min(1.0, ent / max_ent)
+            conf[axis] = round(score, 3)
+        return conf
+
+    def _probe_axes(self, conf: Dict[str, float], styles: List[str], palettes: List[str]) -> Tuple[List[str], List[str]]:
+        """Suggest which axes to probe and the tags to look for in the next images."""
+        probe_axes, probe_tags = [], []
+        if conf.get("style", 0) < 0.55:
+            probe_axes.append("style")
+            # ask for contrasts
+            probe_tags += ["minimalist","maximalist","retro","90s","premium","streetwear","outdoor"]
+        if conf.get("palette", 0) < 0.55:
+            probe_axes.append("palette")
+            probe_tags += ["black","blue","neutral","earthy","pastel","neon"]
+        if conf.get("cohort", 0) < 0.55:
+            probe_axes.append("cohort")
+            probe_tags += ["retro","90s","classic","tiktok","polaroid","vinyl"]
+        # Remove things we already have plural votes for
+        probe_tags = [t for t in probe_tags if t not in set(styles + palettes)]
+        # Make unique, keep short
+        seen, unique_tags = set(), []
+        for t in probe_tags:
+            if t not in seen:
+                seen.add(t); unique_tags.append(t)
+        return probe_axes, unique_tags[:8]
+
+    # ---- multi-query composition -------------------------------------------
+
+    def _compose_queries_multi(
+        self,
+        tokens: List[str],
+        categories: List[str],
+        recipient: str,
+        styles: List[str],
+        palettes: List[str],
+        cohort: Optional[str],
+        budget_aud: Optional[Tuple[int,int]],
+    ) -> List[Tuple[Bucket, str]]:
+        lo, hi = (budget_aud or (None, None))
+        styles_phrase, style_practical = _styles_phrase(styles)
+        palette_phrase = _palette_phrase(palettes)
+        cohort_twist = COHORT_PHRASE.get(cohort or "", "").strip()
+        themes = _themes_from_tokens(tokens)
+
+        # choose buckets based on tokens/categories
+        buckets: List[Bucket] = []
+        if "Fashion" in categories or any(t in tokens for t in ("casual","retro","90s","minimalist")): buckets.append("Fashion")
+        if "Books" in categories or any(t in tokens for t in ("book","books","philosophy","art","tech","design")): buckets.append("Books")
+        if "Tech" in categories or "tech" in tokens: buckets.append("Tech")
+        if "Outdoors" in categories or any(t in tokens for t in ("outdoor","nature","hiking","camping","summer","sun","beach")): buckets.append("Outdoors")
+        if "Home" in categories or "window" in tokens: buckets.append("Home")
+
+        # defaults if nothing detected
+        if not buckets: buckets = ["Tech","Books"]
+
+        # de-dup & cap
+        seen: set[Bucket] = set()
+        deduped: List[Bucket] = []
+        for b in buckets:
+            if b in seen:
+                continue
+            seen.add(b)
+            deduped.append(b)
+            if len(deduped) >= 5:
+                break
+        buckets = deduped
+
+        out: List[Tuple[Bucket, str]] = []
+        for b in buckets:
+            tpl = BUCKET_TEMPLATES[b]
+            q = tpl.format(
+                styles=styles_phrase or "casual",
+                palette=palette_phrase,
+                recipient_phrase=_recipient_phrase(recipient),
+                cohort_twist=(" " + cohort_twist) if cohort_twist else "",
+                style_practical=style_practical or "that are plain and practical",
+                themes=themes,
+                hi=f"${hi}" if hi else "$100",
+            )
+            q = " ".join(q.split())
+            out.append((b, q))
+        return out
+
+    # ---- public entry -------------------------------------------------------
 
     def interpret(
         self,
         tokens: List[str],
-        categories: Optional[List[str]],
-        photo_ids: Optional[List[str]],
-        budget_aud: Optional[Tuple[int, int]] = None,
+        categories: List[str] | None,
+        photo_ids: List[str] | None,
+        budget_aud: Tuple[int,int] | None = None,
         use_llm: bool = True,
-        max_terms: int = 12,
-        ui_recipient: Optional[str] = None,
-        ui_colours: Optional[List[str]] = None,
-        ui_styles: Optional[List[str]] = None,
-        ui_cohort: Optional[str] = None,
+        recipient_hint: Optional[str] = None,   # "me","man","woman","family","couple","teen","kid"
     ) -> Dict[str, Any]:
-        filtered_tokens = _normalise_tokens(tokens)
-        expanded_categories = _expand_categories(
-            filtered_tokens, categories or [], self.manifest
-        )
-        cohort = _infer_cohort(filtered_tokens, photo_ids or [], self.metadata_path)
-        product_terms = _product_seeds(filtered_tokens, expanded_categories, max_terms)
 
-        ordered: List[str] = []
-        seen: set[str] = set()
-        for part in filtered_tokens + expanded_categories + product_terms:
-            if part not in seen:
-                seen.add(part)
-                ordered.append(part)
-        ordered = ordered[: max(8, max_terms)]
-        query_no_llm = " ".join(ordered)
-        if budget_aud:
-            _low, high = budget_aud
-            query_no_llm = f"{query_no_llm} under {high} aud"
+        toks = _normalise(tokens)
+        cats = self._expand_categories(toks, categories or [])
 
-        allowed_terms = list(ordered)
-        if cohort:
-            allowed_terms.append(cohort)
-        query_llm = _llm_rewrite(allowed_terms, cohort, budget_aud) if use_llm else None
+        # infer from selected photos
+        styles, palettes, cohort_meta, ctrs = self._infer_style_palette_cohort(photo_ids or [])
+        conf = self._confidence(ctrs)
 
-        hints: Hints = {}
-        if ui_recipient:
-            hints["recipient"] = ui_recipient
-        if ui_colours:
-            colour_list = [c for c in ui_colours if c]
-            if colour_list:
-                colour_list = list(dict.fromkeys(colour_list))
-            if colour_list:
-                hints["colours"] = colour_list
-        if ui_styles:
-            style_list = [s for s in ui_styles if s]
-            if style_list:
-                style_list = list(dict.fromkeys(style_list))
-            if style_list:
-                hints["styles"] = style_list
-        if budget_aud:
-            lo, hi = budget_aud
-            hints["budget_aud"] = (lo, hi)
-        if ui_cohort:
-            hints["cohort"] = ui_cohort
+        # fallback cohort using tokens if metadata missing
+        cohort = cohort_meta
+        if not cohort:
+            for t in toks:
+                if t in TOKEN_TO_COHORT:
+                    cohort = TOKEN_TO_COHORT[t]; break
 
-        multi_queries = compose_queries_multi(
-            filtered_tokens,
-            expanded_categories,
-            hints,
-            cohort_hint=cohort,
+        # deterministic product seeds (useful for debugging/rerank)
+        product_terms = self._product_seeds(toks, cats, max_terms=12)
+
+        # build allowed term list for optional LLM rewrite
+        allowed_terms = list(dict.fromkeys(toks + cats + styles + palettes + product_terms))
+        if cohort: allowed_terms.append(cohort)
+        llm_phrase = _llm_rewrite(allowed_terms, cohort, budget_aud) if use_llm else None
+
+        # recipient: only infer safely (solo/couple/family would need separate signals)
+        recipient = recipient_hint or "me"
+
+        # compose several bucketed queries (deterministic)
+        queries_multi = self._compose_queries_multi(
+            tokens=toks, categories=cats, recipient=recipient,
+            styles=styles, palettes=palettes, cohort=cohort, budget_aud=budget_aud
         )
 
-        queries_multi: List[Tuple[Bucket, str]] = []
-        for bucket, query_text in multi_queries:
-            allow_terms = query_text.split()
-            rewritten = _llm_rewrite(allow_terms, cohort, budget_aud) if use_llm else None
-            queries_multi.append((bucket, rewritten or query_text))
+        # If LLM produced a neat string, you can optionally replace each query,
+        # but keep it deterministic for now; the LLM is already used for rerank later.
 
-        final_query = (
-            queries_multi[0][1]
-            if queries_multi
-            else (query_llm or query_no_llm)
-        )
+        # decide if we need more images (low confidence on key axes)
+        probe_axes, probe_tags = self._probe_axes(conf, styles, palettes)
+        need_more_images = bool(probe_axes)
 
         return {
-            "tokens": filtered_tokens,
-            "categories": expanded_categories,
+            "tokens": toks,
+            "categories": cats,
+            "styles": styles,
+            "palettes": palettes,
             "cohort": cohort,
+            "confidence": conf,               # e.g., {"style":0.61,"palette":0.48,"cohort":0.35}
             "product_terms": product_terms,
-            "query_no_llm": query_no_llm,
-            "query_llm": query_llm,
-            "queries_multi": queries_multi,
-            "final_query": final_query,
+            "llm_phrase_preview": llm_phrase, # optional; not used if you prefer deterministic
+            "queries_multi": queries_multi,   # [(bucket, query), ...]
+            "need_more_images": need_more_images,
+            "probe_axes": probe_axes,         # e.g., ["palette","cohort"]
+            "probe_tags": probe_tags,         # e.g., ["black","blue","neutral","retro","90s","classic"]
         }

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -101,38 +101,6 @@ def get_query_interpreter(
     return _QUERY_INTERPRETER
 
 
-RECIPIENT_OPTIONS = ["Me", "Woman", "Man", "Teen", "Kid", "Couple", "Family"]
-RECIPIENT_CANON = {opt: opt.lower() for opt in RECIPIENT_OPTIONS}
-RECIPIENT_CANON["Me"] = "me"
-
-PALETTE_OPTIONS = ["Black", "Blue", "Natural", "Warm", "Neon"]
-PALETTE_CANON = {
-    "Black": "black",
-    "Blue": "blue",
-    "Natural": "natural",
-    "Warm": "warm",
-    "Neon": "neon",
-}
-
-STYLE_OPTIONS = ["Casual", "Minimalist", "90s Retro", "Practical", "Premium"]
-STYLE_CANON = {
-    "Casual": ["casual"],
-    "Minimalist": ["minimalist"],
-    "90s Retro": ["retro", "90s"],
-    "Practical": ["practical"],
-    "Premium": ["premium"],
-}
-
-COHORT_OPTIONS = ["Auto", "Gen Z", "Millennial", "Gen X", "Boomer"]
-COHORT_CANON = {
-    "Auto": None,
-    "Gen Z": "Gen Z",
-    "Millennial": "Millennial",
-    "Gen X": "Gen X",
-    "Boomer": "Boomer",
-}
-
-
 # ----------------------- Quiz loading -----------------------
 @st.cache_data
 def load_quiz(path: str = "QuizIA.json") -> Dict[str, Any]:
@@ -1874,48 +1842,15 @@ with tabs[0]:
                 if not taste_top and isinstance(tags, list):
                     taste_top = [str(t) for t in tags if str(t).strip()]
 
-                st.markdown("#### Recipient & Style")
-                hint_cols = st.columns([1.4, 1.2, 1.3, 1.3])
-                with hint_cols[0]:
-                    recipient_choice = st.radio(
-                        "Recipient",
-                        options=RECIPIENT_OPTIONS,
-                        index=0,
-                        horizontal=True,
-                        key="img_recipient_chip",
-                    )
-                with hint_cols[1]:
-                    palette_choice = st.multiselect(
-                        "Palette",
-                        options=PALETTE_OPTIONS,
-                        default=[],
-                        key="img_palette_chip",
-                    )
-                with hint_cols[2]:
-                    style_choice = st.multiselect(
-                        "Style",
-                        options=STYLE_OPTIONS,
-                        default=[],
-                        key="img_style_chip",
-                    )
-                with hint_cols[3]:
-                    apply_budget = st.checkbox("Budget cap", value=True, key="img_budget_cap")
-                    budget_value: Optional[int] = None
-                    if apply_budget:
-                        budget_value = st.slider(
-                            "Max budget ($)",
-                            min_value=20,
-                            max_value=300,
-                            value=100,
-                            step=5,
-                            key="img_budget_slider",
-                        )
-                    cohort_choice = st.selectbox(
-                        "Cohort (optional)",
-                        options=COHORT_OPTIONS,
-                        index=0,
-                        key="img_cohort_select",
-                    )
+                st.markdown("#### Budget")
+                budget_value: int = st.slider(
+                    "Max budget ($)",
+                    min_value=20,
+                    max_value=300,
+                    value=100,
+                    step=5,
+                    key="img_budget_slider",
+                )
 
                 qb = get_query_builder()
                 q_preview, include_cats_prev, debug = qb.compose_with_debug(taste_top)
@@ -1924,24 +1859,10 @@ with tabs[0]:
                 dropped_forbidden = debug.get("dropped_forbidden", [])
                 dropped_not_allowed = debug.get("dropped_not_allowed", [])
 
-                recipient_hint = RECIPIENT_CANON.get(recipient_choice, "me")
-                palette_hints = [
-                    PALETTE_CANON.get(opt, opt.lower()) for opt in palette_choice
-                ]
-                palette_hints = [p for p in palette_hints if p]
-                if palette_hints:
-                    palette_hints = list(dict.fromkeys(palette_hints))
-                style_hints: List[str] = []
-                for opt in style_choice:
-                    style_hints.extend(STYLE_CANON.get(opt, [opt.lower()]))
-                if style_hints:
-                    style_hints = list(dict.fromkeys(style_hints))
-                cohort_hint = COHORT_CANON.get(cohort_choice)
                 budget_tuple: Optional[Tuple[int, int]] = None
                 budget_hi: Optional[int] = None
-                if budget_value is not None:
-                    budget_hi = int(budget_value)
-                    budget_tuple = (0, budget_hi)
+                budget_hi = int(budget_value)
+                budget_tuple = (0, budget_hi)
 
                 interpreter = get_query_interpreter()
                 photo_ids: List[str] = []
@@ -1959,10 +1880,6 @@ with tabs[0]:
                     photo_ids=photo_ids,
                     budget_aud=budget_tuple,
                     use_llm=False,
-                    ui_recipient=recipient_hint,
-                    ui_colours=palette_hints,
-                    ui_styles=style_hints,
-                    ui_cohort=cohort_hint,
                 )
 
                 expanded_categories = interpreter_result.get("categories", include_cats_prev) or []


### PR DESCRIPTION
## Summary
- replace the query interpreter with a metadata-driven implementation that infers styles, palettes, cohorts, and suggests probe tags when confidence is low
- simplify the Streamlit image picker to only capture a max budget before composing queries with the new interpreter
- refresh the interpreter unit tests to cover metadata-driven behaviour and confidence-based probing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbaf58ae20832da205687cb344cecd