### PR TITLE
Fix Streamlit HTML fallback for clickable images

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2080,7 +2080,6 @@ with tabs[0]:
                         """,
                         unsafe_allow_html=True,
                     )
-                    component_key = f"img_choice_html_{st.session_state.get('img_seed', 0)}_{len(bits)}"
                     component_height = 360
                     component_payload = components.html(
                         f"""
@@ -2154,7 +2153,6 @@ with tabs[0]:
                         """,
                         height=component_height,
                         scrolling=False,
-                        key=component_key,
                     )
                     chosen_action: Optional[str] = None
                     if component_payload:


### PR DESCRIPTION
## Summary
- remove the unsupported `key` argument from the `components.html` fallback so the image chooser still renders when `clickable_images` isn't available

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccf6fd1d94832d802a2d720de0c887