### PR TITLE
Restore two-image vibe picker interactions

### DIFF
--- a/app_components/__init__.py
+++ b/app_components/__init__.py
@@ -1,0 +1,3 @@
+"""Custom Streamlit components used by the app."""
+
+__all__ = []

--- a/app_components/image_choice/__init__.py
+++ b/app_components/image_choice/__init__.py
@@ -1,0 +1,40 @@
+"""Simple HTML-based image choice Streamlit component."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Sequence
+
+import streamlit.components.v1 as components
+
+_COMPONENT_FUNC = components.declare_component(
+    "image_choice",
+    path=str(Path(__file__).parent),
+)
+
+
+def _prepare_alts(images: Sequence[str], alts: Optional[Sequence[str]]) -> Sequence[str]:
+    if alts is None:
+        return ["" for _ in images]
+    prepared = [str(a) if a is not None else "" for a in alts]
+    if len(prepared) < len(images):
+        prepared.extend(["" for _ in range(len(images) - len(prepared))])
+    elif len(prepared) > len(images):
+        prepared = prepared[: len(images)]
+    return prepared
+
+
+def image_choice(
+    *,
+    images: Sequence[str],
+    alts: Optional[Sequence[str]] = None,
+    key: Optional[str] = None,
+) -> Optional[str]:
+    """Render two selectable images and return the chosen action."""
+
+    safe_images = [str(src) if src is not None else "" for src in images]
+    safe_alts = list(_prepare_alts(safe_images, alts))
+    return _COMPONENT_FUNC(images=safe_images, alts=safe_alts, key=key, default=None)
+
+
+__all__ = ["image_choice"]

--- a/app_components/image_choice/index.html
+++ b/app_components/image_choice/index.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <script src="https://unpkg.com/streamlit-component-lib@1.4.0/dist/index.js"></script>
+    <style>
+      :root {
+        color-scheme: light;
+      }
+      body {
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        color: #2c2c2c;
+      }
+      .img-choice-grid {
+        display: flex;
+        justify-content: space-between;
+        gap: 1rem;
+        align-items: stretch;
+      }
+      .img-choice-grid button {
+        flex: 1;
+        border: none;
+        padding: 0;
+        border-radius: 12px;
+        overflow: hidden;
+        background-color: #fff;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+      }
+      .img-choice-grid button:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
+      }
+      .img-choice-grid button:focus-visible {
+        outline: 3px solid #4a90e2;
+        outline-offset: 3px;
+      }
+      .img-choice-grid img {
+        width: 100%;
+        height: 240px;
+        object-fit: cover;
+        display: block;
+      }
+      .img-choice-actions {
+        margin-top: 1rem;
+        text-align: center;
+      }
+      .img-choice-actions button {
+        border: 1px solid #444;
+        background: transparent;
+        color: #444;
+        padding: 0.6rem 1.6rem;
+        border-radius: 999px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+      }
+      .img-choice-actions button:hover,
+      .img-choice-actions button:focus-visible {
+        background: #444;
+        color: #fff;
+        border-color: #444;
+      }
+      .img-choice-empty {
+        text-align: center;
+        font-size: 0.9rem;
+        color: #666;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script>
+      const root = document.getElementById("root");
+      const { Streamlit } = window;
+
+      function render(event) {
+        const args = event.detail.args || {};
+        const images = Array.isArray(args.images) ? args.images : [];
+        const alts = Array.isArray(args.alts) ? args.alts : [];
+        root.innerHTML = "";
+
+        if (images.length >= 2) {
+          const grid = document.createElement("div");
+          grid.className = "img-choice-grid";
+          for (let idx = 0; idx < 2; idx += 1) {
+            const src = images[idx] || "";
+            const alt = alts[idx] || "";
+            const button = document.createElement("button");
+            button.type = "button";
+            button.dataset.choice = idx === 0 ? "left" : "right";
+            const img = document.createElement("img");
+            img.src = src;
+            img.alt = alt;
+            button.appendChild(img);
+            grid.appendChild(button);
+          }
+          root.appendChild(grid);
+
+          const actions = document.createElement("div");
+          actions.className = "img-choice-actions";
+          const neither = document.createElement("button");
+          neither.type = "button";
+          neither.dataset.choice = "neither";
+          neither.textContent = "Neither match";
+          actions.appendChild(neither);
+          root.appendChild(actions);
+        } else {
+          const empty = document.createElement("div");
+          empty.className = "img-choice-empty";
+          empty.textContent = "Add two images to compare.";
+          root.appendChild(empty);
+        }
+
+        root.querySelectorAll("[data-choice]").forEach((el) => {
+          el.addEventListener("click", (eventClick) => {
+            eventClick.preventDefault();
+            eventClick.stopPropagation();
+            const choice = el.dataset.choice || null;
+            if (choice && Streamlit && typeof Streamlit.setComponentValue === "function") {
+              Streamlit.setComponentValue(choice);
+            }
+          });
+        });
+
+        if (Streamlit && typeof Streamlit.setFrameHeight === "function") {
+          const height = root.getBoundingClientRect().height + 16;
+          Streamlit.setFrameHeight(height);
+        }
+      }
+
+      if (Streamlit) {
+        Streamlit.events.addEventListener(Streamlit.RENDER_EVENT, (event) => {
+          render(event);
+        });
+        Streamlit.setComponentReady();
+        Streamlit.setFrameHeight(0);
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- restore the two-image vibe picker by reworking the Streamlit logic to keep the clickable experience without relying on query-string navigation
- add a lightweight custom component that renders the paired images with a center "Neither match" call-to-action when the `clickable_images` package is unavailable

## Testing
- python -m compileall Constructor_Tests/streamlit_app.py Constructor_Tests/app_components/image_choice/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68ccf9be4be0832d843bad31e298edce